### PR TITLE
Deploy more easily & update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,17 @@ First install s3cmd:
 
     brew install s3cmd  
 
-Then put it recursively to the espark-refresh bucket:
+Configure s3cmd
+
+    s3cmd --configure
+
+Create an IAM user on AWS and download the credentials, add them when prompted
+
+Now push the repo recursively to the appropriate AWS bucket:
   
     cd _site  
     s3cmd put --recursive * s3://whatsocksdoeswillhaveontoday.com/
 
-Use your eSpark Amazon AWS credentials.
+Or use the executable
+
+    bin/deploy

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,1 @@
+s3cmd put --recursive _site/* s3://whatsocksdoeswillhaveontoday.com/


### PR DESCRIPTION
Instead of copy/pasting what is in the README every time, this diff adds an executable script in `bin/deploy` to push the website. Now to deploy all you have to do is

    $ bin/deploy

